### PR TITLE
 Renamed export_network/export_subnet to import_network/import_subnet…

### DIFF
--- a/daisy_integration_tests/image_import_and_translate_custom_network_latest.wf.json
+++ b/daisy_integration_tests/image_import_and_translate_custom_network_latest.wf.json
@@ -38,8 +38,8 @@
           "image_name": "${image_name}",
           "source_disk_file": "${source_disk_file}",
           "translate_workflow": "ubuntu/translate_ubuntu_1604.wf.json",
-          "export_network": "my-network",
-          "export_subnet": "my-subnetwork"
+          "import_network": "my-network",
+          "import_subnet": "my-subnetwork"
         }
       }
     },

--- a/daisy_integration_tests/image_import_and_translate_nondefault_network_latest.wf.json
+++ b/daisy_integration_tests/image_import_and_translate_nondefault_network_latest.wf.json
@@ -28,7 +28,7 @@
           "image_name": "${image_name}",
           "source_disk_file": "${source_disk_file}",
           "translate_workflow": "ubuntu/translate_ubuntu_1604.wf.json",
-          "export_network": "my-network"
+          "import_network": "my-network"
         }
       }
     },

--- a/daisy_workflows/image_import/debian/translate_debian.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian.wf.json
@@ -13,11 +13,11 @@
       "Required": true,
       "Description": "The name of the imported GCE disk resource."
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -58,8 +58,8 @@
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}",
-              "subnetwork": "${export_subnet}"
+              "network": "${import_network}",
+              "subnetwork": "${import_subnet}"
             }
           ],
           "StartupScript": "startup_script"

--- a/daisy_workflows/image_import/debian/translate_debian_8.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian_8.wf.json
@@ -21,11 +21,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -38,8 +38,8 @@
           "debian_release": "jessie",
           "install_gce_packages": "${install_gce_packages}",
           "imported_disk": "${source_disk}",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/debian/translate_debian_9.wf.json
+++ b/daisy_workflows/image_import/debian/translate_debian_9.wf.json
@@ -21,11 +21,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -38,8 +38,8 @@
           "debian_release": "stretch",
           "install_gce_packages": "${install_gce_packages}",
           "imported_disk": "${source_disk}",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_6.wf.json
@@ -21,11 +21,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -49,8 +49,8 @@
           "install_gce_packages": "${install_gce_packages}",
           "translator_disk": "disk-translator",
           "imported_disk": "${source_disk}",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_centos_7.wf.json
@@ -21,11 +21,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -49,8 +49,8 @@
           "install_gce_packages": "${install_gce_packages}",
           "translator_disk": "disk-translator",
           "imported_disk": "${source_disk}",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_el.wf.json
@@ -21,11 +21,11 @@
       "Value": "false",
       "Description": "Whether to use a GCE RHEL license or not."
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -57,8 +57,8 @@
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}",
-              "subnetwork": "${export_subnet}"
+              "network": "${import_network}",
+              "subnetwork": "${import_subnet}"
             }
           ],
           "StartupScript": "startup_script"

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_byol.wf.json
@@ -21,11 +21,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -49,8 +49,8 @@
           "install_gce_packages": "${install_gce_packages}",
           "translator_disk": "disk-translator",
           "imported_disk": "${source_disk}",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_6_licensed.wf.json
@@ -21,11 +21,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -50,8 +50,8 @@
           "translator_disk": "disk-translator",
           "imported_disk": "${source_disk}",
           "use_rhel_gce_license": "true",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_byol.wf.json
@@ -21,11 +21,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -49,8 +49,8 @@
           "install_gce_packages": "${install_gce_packages}",
           "translator_disk": "disk-translator",
           "imported_disk": "${source_disk}",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
+++ b/daisy_workflows/image_import/enterprise_linux/translate_rhel_7_licensed.wf.json
@@ -21,11 +21,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -50,8 +50,8 @@
           "translator_disk": "disk-translator",
           "imported_disk": "${source_disk}",
           "use_rhel_gce_license": "true",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
+++ b/daisy_workflows/image_import/freebsd/translate_freebsd.wf.json
@@ -21,11 +21,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -65,8 +65,8 @@
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}",
-              "subnetwork": "${export_subnet}"
+              "network": "${import_network}",
+              "subnetwork": "${import_subnet}"
             }
           ],
           "StartupScript": "startup_script"

--- a/daisy_workflows/image_import/import_and_translate.wf.json
+++ b/daisy_workflows/image_import/import_and_translate.wf.json
@@ -27,11 +27,11 @@
       "Description": "Optional description to set for the translated image"
     },
     "translation-disk-name": "temp-translation-disk-${ID}",
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -43,8 +43,8 @@
         "Vars": {
           "source_disk_file": "${source_disk_file}",
           "disk_name": "${translation-disk-name}",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       }
     },
@@ -64,8 +64,8 @@
           "install_gce_packages": "${install_gce_packages}",
           "family": "${family}",
           "description": "${description}",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       }
     },

--- a/daisy_workflows/image_import/import_disk.wf.json
+++ b/daisy_workflows/image_import/import_disk.wf.json
@@ -15,11 +15,11 @@
       "Description": "image to use for the importer instance"
     },
     "disk_name": "imported-disk-${ID}",
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -59,8 +59,8 @@
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}",
-              "subnetwork": "${export_subnet}"
+              "network": "${import_network}",
+              "subnetwork": "${import_subnet}"
             }
           ],
           "Scopes": [

--- a/daisy_workflows/image_import/import_from_image.wf.json
+++ b/daisy_workflows/image_import/import_from_image.wf.json
@@ -26,11 +26,11 @@
       "Description": "Optional description to set for the translated image"
     },
     "disk_name": "imported-disk-${ID}",
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }

--- a/daisy_workflows/image_import/import_image.wf.json
+++ b/daisy_workflows/image_import/import_image.wf.json
@@ -27,11 +27,11 @@
       "Description": "Optional description to set for the imported image"
     },
     "import_disk_name": "imported-disk-${ID}",
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -45,8 +45,8 @@
           "importer_instance_disk_size": "${importer_instance_disk_size}",
           "disk_name": "${import_disk_name}",
           "import_instance_disk_image": "${import_instance_disk_image}",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       }
     },

--- a/daisy_workflows/image_import/suse/translate_suse.wf.json
+++ b/daisy_workflows/image_import/suse/translate_suse.wf.json
@@ -21,11 +21,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -65,8 +65,8 @@
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}",
-              "subnetwork": "${export_subnet}"
+              "network": "${import_network}",
+              "subnetwork": "${import_subnet}"
             }
           ],
           "StartupScript": "startup_script"

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu.wf.json
@@ -13,11 +13,11 @@
       "Required": true,
       "Description": "The name of the imported GCE disk resource."
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -58,8 +58,8 @@
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}",
-              "subnetwork": "${export_subnet}"
+              "network": "${import_network}",
+              "subnetwork": "${import_subnet}"
             }
           ],
           "StartupScript": "startup_script"

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1404.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1404.wf.json
@@ -21,11 +21,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -38,8 +38,8 @@
           "ubuntu_release": "trusty",
           "install_gce_packages": "${install_gce_packages}",
           "imported_disk": "${source_disk}",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1604.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1604.wf.json
@@ -21,13 +21,13 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
-      "Description": "Network to use for the export instance"
+      "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
-      "Description": "SubNetwork to use for the export instance"
+      "Description": "SubNetwork to use for the import instance"
     }
   },
   "Steps": {
@@ -38,8 +38,8 @@
           "ubuntu_release": "xenial",
           "install_gce_packages": "${install_gce_packages}",
           "imported_disk": "${source_disk}",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/ubuntu/translate_ubuntu_1804.wf.json
+++ b/daisy_workflows/image_import/ubuntu/translate_ubuntu_1804.wf.json
@@ -21,11 +21,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -38,8 +38,8 @@
           "ubuntu_release": "bionic",
           "install_gce_packages": "${install_gce_packages}",
           "imported_disk": "${source_disk}",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/windows/translate_windows_2003.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2003.wf.json
@@ -21,11 +21,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -59,8 +59,8 @@
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}",
-              "subnetwork": "${export_subnet}"
+              "network": "${import_network}",
+              "subnetwork": "${import_subnet}"
             }
           ],
           "StartupScript": "bootstrap.ps1"

--- a/daisy_workflows/image_import/windows/translate_windows_2008_r2.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2008_r2.wf.json
@@ -25,11 +25,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -46,8 +46,8 @@
           "version": "6.1",
           "task_reg": "./task_reg_2008r2",
           "task_xml": "./task_xml",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/windows/translate_windows_2008_r2_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2008_r2_byol.wf.json
@@ -25,11 +25,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -47,8 +47,8 @@
           "task_reg": "./task_reg_2008r2",
           "task_xml": "./task_xml",
           "byol": "true",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/windows/translate_windows_2012.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2012.wf.json
@@ -25,11 +25,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -46,8 +46,8 @@
           "version": "6.2",
           "task_reg": "./task_reg_2012r2",
           "task_xml": "./task_xml",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/windows/translate_windows_2012_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2012_byol.wf.json
@@ -25,11 +25,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -47,8 +47,8 @@
           "task_reg": "./task_reg_2012r2",
           "task_xml": "./task_xml",
           "byol": "true",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/windows/translate_windows_2012_r2.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2012_r2.wf.json
@@ -25,11 +25,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -46,8 +46,8 @@
           "version": "6.3",
           "task_reg": "./task_reg_2012r2",
           "task_xml": "./task_xml",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/windows/translate_windows_2012_r2_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2012_r2_byol.wf.json
@@ -25,11 +25,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -47,8 +47,8 @@
           "task_reg": "./task_reg_2012r2",
           "task_xml": "./task_xml",
           "byol": "true",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/windows/translate_windows_2016.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2016.wf.json
@@ -25,11 +25,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -46,8 +46,8 @@
           "version": "10.0",
           "task_reg": "./task_reg_2016",
           "task_xml": "./task_xml",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/windows/translate_windows_2016_byol.wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_2016_byol.wf.json
@@ -25,11 +25,11 @@
       "Value": "",
       "Description": "Optional description to set for the translated image"
     },
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -47,8 +47,8 @@
           "task_reg": "./task_reg_2016",
           "task_xml": "./task_xml",
           "byol": "true",
-          "export_network": "${export_network}",
-          "export_subnet": "${export_subnet}"
+          "import_network": "${import_network}",
+          "import_subnet": "${import_subnet}"
         }
       },
       "Timeout": "60m"

--- a/daisy_workflows/image_import/windows/translate_windows_wf.json
+++ b/daisy_workflows/image_import/windows/translate_windows_wf.json
@@ -28,11 +28,11 @@
       "Required": true
     },
     "byol": "false",
-    "export_network": {
+    "import_network": {
       "Value": "global/networks/default",
       "Description": "Network to use for the import instance"
     },
-    "export_subnet": {
+    "import_subnet": {
       "Value": "",
       "Description": "SubNetwork to use for the import instance"
     }
@@ -70,8 +70,8 @@
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}",
-              "subnetwork": "${export_subnet}"
+              "network": "${import_network}",
+              "subnetwork": "${import_subnet}"
             }
           ],
           "StartupScript": "translate_bootstrap.ps1"
@@ -113,8 +113,8 @@
           },
           "networkInterfaces": [
             {
-              "network": "${export_network}",
-              "subnetwork": "${export_subnet}"
+              "network": "${import_network}",
+              "subnetwork": "${import_subnet}"
             }
           ],
           "StartupScript": "translate.ps1"


### PR DESCRIPTION
… for import workflows (#591)

* Added subnet variable to image and disk export workflows.
Passing this variable to CreateInstance step. Specifying subnet is necessary when a
GCP project has custom network setup.

* Added integration tests for Daisy export with non-default network and network with custom subnetworks.

* Added support for network/subnet to Daisy import workflows.

Added integration tests for Daisy import with non-default network and network with custom subnetworks.

* Renamed export_network/export_subnet to import_network/import_subnet for import workflows