### PR TITLE
VM image importer/wrapper (#639)

### DIFF
--- a/Dockerfile.gce_vm_image_import
+++ b/Dockerfile.gce_vm_image_import
@@ -1,0 +1,21 @@
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/distroless/base
+
+COPY linux/gce_vm_image_import /gce_vm_image_import
+COPY daisy_workflows/ /daisy_workflows/
+
+WORKDIR /
+ENTRYPOINT ["/gce_vm_image_import"]

--- a/cli_tools/daisy_common/daisy_utils.go
+++ b/cli_tools/daisy_common/daisy_utils.go
@@ -1,0 +1,83 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package daisycommon
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/compute/metadata"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+)
+
+// ParseWorkflow parses Daisy workflow file and returns Daisy workflow object or error in case of failure
+func ParseWorkflow(ctx context.Context, path string, varMap map[string]string, project, zone, gcsPath, oauth, dTimeout, cEndpoint string, disableGCSLogs, diableCloudLogs, disableStdoutLogs bool) (*daisy.Workflow, error) {
+	w, err := daisy.NewFromFile(path)
+	if err != nil {
+		return nil, err
+	}
+Loop:
+	for k, v := range varMap {
+		for wv := range w.Vars {
+			if k == wv {
+				w.AddVar(k, v)
+				continue Loop
+			}
+		}
+		return nil, fmt.Errorf("unknown workflow Var %q passed to Workflow %q", k, w.Name)
+	}
+
+	if project != "" {
+		w.Project = project
+	} else if w.Project == "" && metadata.OnGCE() {
+		w.Project, err = metadata.ProjectID()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if zone != "" {
+		w.Zone = zone
+	} else if w.Zone == "" && metadata.OnGCE() {
+		w.Zone, err = metadata.Zone()
+		if err != nil {
+			return nil, err
+		}
+	}
+	if gcsPath != "" {
+		w.GCSPath = gcsPath
+	}
+	if oauth != "" {
+		w.OAuthPath = oauth
+	}
+	if dTimeout != "" {
+		w.DefaultTimeout = dTimeout
+	}
+
+	if cEndpoint != "" {
+		w.ComputeEndpoint = cEndpoint
+	}
+
+	if disableGCSLogs {
+		w.DisableGCSLogging()
+	}
+	if diableCloudLogs {
+		w.DisableCloudLogging()
+	}
+	if disableStdoutLogs {
+		w.DisableStdoutLogging()
+	}
+
+	return w, nil
+}

--- a/cli_tools/daisy_common/daisy_utils_test.go
+++ b/cli_tools/daisy_common/daisy_utils_test.go
@@ -1,0 +1,57 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package daisycommon
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestParseWorkflows(t *testing.T) {
+	path := "../../daisy/test_data/test.wf.json"
+	varMap := map[string]string{"key1": "var1", "key2": "var2"}
+	project := "project"
+	zone := "zone"
+	gcsPath := "gcspath"
+	oauth := "oauthpath"
+	dTimeout := "10m"
+	endpoint := "endpoint"
+	w, err := ParseWorkflow(context.Background(), path, varMap, project, zone, gcsPath, oauth, dTimeout, endpoint, true, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		want, got interface{}
+	}{
+		{w.Project, project},
+		{w.Zone, zone},
+		{w.GCSPath, gcsPath},
+		{w.OAuthPath, oauth},
+		{w.DefaultTimeout, dTimeout},
+		{w.ComputeEndpoint, endpoint},
+	}
+
+	for _, tt := range tests {
+		if tt.want != tt.got {
+			t.Errorf("%v != %v", tt.want, tt.got)
+		}
+	}
+
+	if reflect.DeepEqual(w.Vars, varMap) {
+		t.Errorf("unexpected vars, want: %v, got: %v", varMap, w.Vars)
+	}
+}

--- a/cli_tools/gce_vm_image_import/README.md
+++ b/cli_tools/gce_vm_image_import/README.md
@@ -1,0 +1,82 @@
+## Compute Engine VM Image Import
+
+The `gce_vm_image_import` tool imports a VM image to Google Compute Engine
+image. It uses Daisy to perform imports while adding additional logic to perform
+import setup and clean-up, such as creating a temporary bucket, validating
+flags etc.  
+
+### Build
+Download and install [Go](https://golang.org/doc/install). Then pull and 
+install the `gce_vm_image_import` tool, this should place the binary in the 
+[Go bin directory](https://golang.org/doc/code.html#GOPATH):
+
+```
+go get github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import
+```
+
+### Flags
+
+#### Required flags
++ `-image_name` Name of the disk image to create.
++ `-client_id` Identifies the client of the importer. For example: `gcloud` or
+  `pantheon`.
+  
+Exactly one of these must be specified:
++ `-data_disk` Specifies that the disk has no bootable OS installed on it. 
+   Imports the disk without making it bootable or installing Google tools on it.   
++ `-os=OS` Specifies the OS of the image being imported. 
+  OS must be one of: centos-6, centos-7, debian-8, debian-9, rhel-6, 
+  rhel-6-byol, rhel-7, rhel-7-byol, ubuntu-1404, ubuntu-1604, windows-2008r2, 
+  windows-2012r2, windows-2016.
+  
+Exactly one of these must be specified:
++ `-source_file=SOURCE_FILE` Google Cloud Storage URI of the virtual disk file
+  to import. For example: gs://my-bucket/my-image.vmdk.
++ `-source_image=SOURCE_IMAGE` An existing Compute Engine image from which to 
+  import.
+
+#### Optional flags  
++ `-no_guest_environment` Google Guest Environment will not be installed on the image.
++ `-family=FAMILY` Family to set for the translated image.
++ `-description=DESCRIPTION` Description to set for the translated image.
++ `-network=NETWORK` Name of the network in your project to use for the image import. The network 
+  must have access to Google Cloud Storage. If not specified, the  network named 'default' is used.
++ `-subnet=SUBNET` Name of the subnetwork in your project to use for the image import. If the 
+  network resource is in legacy mode, do not provide this property. If the network is in auto subnet 
+  mode, providing the subnetwork is optional. If the network is in custom subnet mode, then this 
+  field should be specified. Region or zone should be specified if this field is specified.
++ `-zone=ZONE` Zone of the image to import. The zone in which to do the work of
+  importing the image. Overrides the default compute/zone property value for
+  this command invocation.  
++ `-timeout=TIMEOUT; default="2h"` Maximum time a build can last before it is
+  failed as "TIMEOUT". For example, specifying 2h will fail the process after 
+  2 hours. See $ gcloud topic datetimes for information on duration formats.
++ `-project=PROJECT` Project to run in, overrides what is set in workflow.
++ `-scratch_bucket_gcs_path=PATH` GCS scratch bucket to use, overrides default set in Daisy.
++ `-oauth=OAUTH_PATH` Path to oauth json file, overrides what is set in workflow.
++ `-compute_endpoint_override=ENDPOINT` Compute API endpoint to override default.
++ `-disable_gcs_logging` Do not stream logs to GCS
++ `-disable_cloud_logging` Do not stream logs to Cloud Logging
++ `-disable_stdout_logging` Do not display individual workflow logs on stdout
++ `-kms-key=KMS_KEY_ID` ID of the key or fully qualified identifier for the key. This flag
+  must be specified if any of the other arguments below are specified.
++ `-kms-keyring=KMS_KEYRING` The KMS keyring of the key.
++ `-kms-location=KMS_LOCATION` The Cloud location for the key.
++ `-kms-project=KMS_PROJECT` The Cloud project for the key
++ `-no_external_ip` Set if VPC does not allow external IPs
++ `-labels=[KEY=VALUE,...]` labels: List of label KEY=VALUE pairs to add. Keys must start with a
+  lowercase character and contain only hyphens (-), underscores (_), lowercase characters, and 
+  numbers. Values must contain only hyphens (-), underscores (_), lowercase characters, and numbers.
+  
+### Usage
+
+```
+gce_vm_image_import -image_name IMAGE_NAME -client_id CLIENT_ID (-data-disk | -os=OS)
+        (-source-file=SOURCE_FILE | -source-image=SOURCE_IMAGE) [-no-guest-environment] 
+        [-log-location=LOG_LOCATION] [-family=FAMILY] [-description=DESCRIPTION]
+        [-network=NETWORK] [-subnet=SUBNET] [-zone=ZONE] [-timeout=TIMEOUT; default="2h"]
+        [-project=PROJECT] [-scratch_bucket_gcs_path=PATH] [-oauth=OAUTH_PATH]
+        [-compute_endpoint_override=ENDPOINT] [-disable_gcs_logging] [-disable_cloud_logging]
+        [-disable_stdout_logging] [-kms-key=KMS_KEY -kms-keyring=KMS_KEYRING
+        -kms-location=KMS_LOCATION -kms-project=KMS_PROJECT] [-labels=KEY=VALUE,...]
+```

--- a/cli_tools/gce_vm_image_import/main.go
+++ b/cli_tools/gce_vm_image_import/main.go
@@ -1,0 +1,409 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+// GCE VM image import tool
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"cloud.google.com/go/compute/metadata"
+	"github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/daisy_common"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	"google.golang.org/api/compute/v1"
+)
+
+const (
+	workflowDir                = "daisy_workflows/image_import/"
+	importWorkflow             = workflowDir + "import_image.wf.json"
+	importFromImageWorkflow    = workflowDir + "import_from_image.wf.json"
+	importAndTranslateWorkflow = workflowDir + "import_and_translate.wf.json"
+	imageNameFlagKey           = "image_name"
+	clientIDFlagKey            = "client_id"
+)
+
+var (
+	imageName            = flag.String(imageNameFlagKey, "", "Image name to be imported.")
+	clientID             = flag.String(clientIDFlagKey, "", "Identifies the client of the importer, e.g. `gcloud` or `pantheon`")
+	dataDisk             = flag.Bool("data_disk", false, "Specifies that the disk has no bootable OS installed on it.	Imports the disk without making it bootable or installing Google tools on it. ")
+	osID                 = flag.String("os", "", "Specifies the OS of the image being imported. Must be one of: centos-6, centos-7, debian-8, debian-9, rhel-6, rhel-6-byol, rhel-7, rhel-7-byol, ubuntu-1404, ubuntu-1604, windows-2008r2, windows-2012r2, windows-2016.")
+	sourceFile           = flag.String("source_file", "", "Google Cloud Storage URI of the virtual disk file	to import. For example: gs://my-bucket/my-image.vmdk")
+	sourceImage          = flag.String("source_image", "", "Compute Engine image from which to import")
+	noGuestEnvironment   = flag.Bool("no_guest_environment", false, "Google Guest Environment will not be installed on the image.")
+	family               = flag.String("family", "", "Family to set for the translated image")
+	description          = flag.String("description", "", "Description to set for the translated image")
+	network              = flag.String("network", "", "Name of the network in your project to use for the image import. The network must have access to Google Cloud Storage. If not specified, the network named default is used.")
+	subnet               = flag.String("subnet", "", "Name of the subnetwork in your project to use for the image import. If	the network resource is in legacy mode, do not provide this property. If the network is in auto subnet mode, providing the subnetwork is optional. If the network is in custom subnet mode, then this field should be specified. Zone should be specified if this field is specified.")
+	zone                 = flag.String("zone", "", "Zone of the image to import. The zone in which to do the work of importing the image. Overrides the default compute/zone property value for this command invocation.")
+	timeout              = flag.String("timeout", "", "Maximum time a build can last before it is failed as TIMEOUT. For example, specifying 2h will fail the process after 2 hours. See $ gcloud topic datetimes for information on duration formats.")
+	project              = flag.String("project", "", "project to run in, overrides what is set in workflow")
+	scratchBucketGcsPath = flag.String("scratch_bucket_gcs_path", "", "GCS scratch bucket to use, overrides what is set in workflow")
+	oauth                = flag.String("oauth", "", "path to oauth json file, overrides what is set in workflow")
+	ce                   = flag.String("compute_endpoint_override", "", "API endpoint to override default")
+	gcsLogsDisabled      = flag.Bool("disable_gcs_logging", false, "do not stream logs to GCS")
+	cloudLogsDisabled    = flag.Bool("disable_cloud_logging", false, "do not stream logs to Cloud Logging")
+	stdoutLogsDisabled   = flag.Bool("disable_stdout_logging", false, "do not display individual workflow logs on stdout")
+	kmsKey               = flag.String("kms_key", "", "ID of the key or fully qualified identifier for the key. This flag must be specified if any of the other arguments below are specified.")
+	kmsKeyring           = flag.String("kms_keyring", "", "The KMS keyring of the key.")
+	kmsLocation          = flag.String("kms_location", "", "The Cloud location for the key.")
+	kmsProject           = flag.String("kms_project", "", "The Cloud project for the key")
+	noExternalIP         = flag.Bool("no_external_ip", false, "VPC doesn't allow external IPs")
+	labels               = flag.String("labels", "", "List of label KEY=VALUE pairs to add. Keys must start with a lowercase character and contain only hyphens (-), underscores (_), lowercase characters, and numbers. Values must contain only hyphens (-), underscores (_), lowercase characters, and numbers.")
+
+	region    *string
+	buildID   = os.Getenv("BUILD_ID")
+	gsRegex   = regexp.MustCompile(`^gs://([a-z0-9][-_.a-z0-9]*)/(.+)$`)
+	osChoices = map[string]string{
+		"debian-8":       "debian/translate_debian_8.wf.json",
+		"debian-9":       "debian/translate_debian_9.wf.json",
+		"centos-6":       "enterprise_linux/translate_centos_6.wf.json",
+		"centos-7":       "enterprise_linux/translate_centos_7.wf.json",
+		"rhel-6":         "enterprise_linux/translate_rhel_6_licensed.wf.json",
+		"rhel-7":         "enterprise_linux/translate_rhel_7_licensed.wf.json",
+		"rhel-6-byol":    "enterprise_linux/translate_rhel_6_byol.wf.json",
+		"rhel-7-byol":    "enterprise_linux/translate_rhel_7_byol.wf.json",
+		"ubuntu-1404":    "ubuntu/translate_ubuntu_1404.wf.json",
+		"ubuntu-1604":    "ubuntu/translate_ubuntu_1604.wf.json",
+		"windows-2008r2": "windows/translate_windows_2008_r2.wf.json",
+		"windows-2012r2": "windows/translate_windows_2012_r2.wf.json",
+		"windows-2016":   "windows/translate_windows_2016.wf.json",
+	}
+	userLabels *map[string]string
+)
+
+func validateAndParseFlags() error {
+	flag.Parse()
+
+	if err := validateStringFlag(*imageName, imageNameFlagKey); err != nil {
+		return err
+	}
+	if err := validateStringFlag(*clientID, clientIDFlagKey); err != nil {
+		return err
+	}
+
+	if !*dataDisk && *osID == "" {
+		return fmt.Errorf("-data_disk or -os has to be specified")
+	}
+
+	if *dataDisk && *osID != "" {
+		return fmt.Errorf("either -data_disk or -os has to be specified, but not both")
+	}
+
+	if *sourceFile == "" && *sourceImage == "" {
+		return fmt.Errorf("-source_file or -source_image has to be specified")
+	}
+
+	if *sourceFile != "" && *sourceImage != "" {
+		return fmt.Errorf("either -source_file or -source_image has to be specified, but not both %v %v", *sourceFile, *sourceImage)
+	}
+
+	if *osID != "" {
+		if _, osValid := osChoices[*osID]; !osValid {
+			return fmt.Errorf("os %v is invalid. Allowed values: %v", *osID, reflect.ValueOf(osChoices).MapKeys())
+		}
+	}
+
+	if *sourceFile != "" {
+		_, _, err := splitGCSPath(*sourceFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	if *labels != "" {
+		var err error
+		userLabels, err = parseUserLabels(labels)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func parseUserLabels(labelsFlag *string) (*map[string]string, error) {
+	labelsMap := make(map[string]string)
+	splits := strings.Split(*labelsFlag, ",")
+	for _, split := range splits {
+		if len(split) == 0 {
+			continue
+		}
+		key, value, err := parseUserLabel(split)
+		if err != nil {
+			return nil, err
+		}
+		labelsMap[key] = value
+	}
+	return &labelsMap, nil
+}
+
+func parseUserLabel(labelSplit string) (string, string, error) {
+	splits := strings.Split(labelSplit, "=")
+	if len(splits) != 2 {
+		return "", "", fmt.Errorf("Label specification should be in the following format: LABEL_KEY=LABEL_VALUE, but it's %v", labelSplit)
+	}
+	key := strings.TrimSpace(splits[0])
+	value := strings.TrimSpace(splits[1])
+	if len(key) == 0 {
+		return "", "", fmt.Errorf("Label key is empty string: %v", labelSplit)
+	}
+	if len(value) == 0 {
+		return "", "", fmt.Errorf("Label value is empty string: %v", labelSplit)
+	}
+	return key, value, nil
+}
+
+func validateStringFlag(flagValue string, flagKey string) error {
+	return validateString(flagValue, flagKey, "The flag -%v must be provided")
+}
+
+func validateString(value string, key string, errorMessage string) error {
+	if value == "" {
+		return fmt.Errorf(errorMessage, key)
+	}
+	return nil
+}
+
+func splitGCSPath(p string) (string, string, error) {
+	matches := gsRegex.FindStringSubmatch(p)
+	if matches != nil {
+		return matches[1], matches[2], nil
+	}
+
+	return "", "", fmt.Errorf("%q is not a valid GCS path", p)
+}
+
+//Returns main workflow and translate workflow paths (if any)
+func getWorkflowPaths() (string, string) {
+	if *sourceImage != "" {
+		return importFromImageWorkflow, getTranslateWorkflowPath(osID)
+	}
+	if *dataDisk {
+		return importWorkflow, ""
+	}
+	return importAndTranslateWorkflow, getTranslateWorkflowPath(osID)
+}
+
+func getTranslateWorkflowPath(os *string) string {
+	return osChoices[*os]
+}
+
+func fatalIfError(f func() error) {
+	if err := f(); err != nil {
+		log.Fatalf(err.Error())
+	}
+}
+
+func populateMissingParameters() {
+	fatalIfError(func() error {
+		return populateZoneIfMissing(metadataGCEHolder{})
+	})
+	fatalIfError(populateRegion)
+
+	//TODO: network, subnetwork, gcsPath (create scratch bucket including regionalization, if possible)
+}
+
+type metadataGCEHolder struct{}
+
+type metadataGCE interface {
+	OnGCE() bool
+	Zone() (string, error)
+}
+
+func (m metadataGCEHolder) OnGCE() bool {
+	return metadata.OnGCE()
+}
+
+func (m metadataGCEHolder) Zone() (string, error) {
+	return metadata.Zone()
+}
+
+func populateZoneIfMissing(mgce metadataGCE) error {
+	if *zone == "" {
+		var err error
+		var aZone = ""
+		if mgce.OnGCE() {
+			aZone, err = mgce.Zone()
+		}
+
+		if err != nil {
+			return fmt.Errorf("can't infer zone: %v", err)
+		}
+		if aZone == "" {
+			return fmt.Errorf("zone is empty")
+		}
+
+		zone = &aZone
+	}
+	return nil
+}
+
+func populateRegion() error {
+	aRegion, err := getRegion()
+	if err != nil {
+		return err
+	}
+	region = &aRegion
+	return nil
+}
+
+func getRegion() (string, error) {
+	if *zone == "" {
+		return "", fmt.Errorf("zone is empty. Can't determine region")
+	}
+	zoneStrs := strings.Split(*zone, "-")
+	if len(zoneStrs) < 2 {
+		return "", fmt.Errorf("%v is not a valid zone", *zone)
+	}
+	return strings.Join(zoneStrs[:len(zoneStrs)-1], "-"), nil
+}
+
+// Updates workflow to support image import:
+// - Labels temporary and permanent resources with appropriate labels
+// - Updates instance network interfaces to not require external IP if external IP is disabled by
+//   org policy
+func updateWorkflow(workflow *daisy.Workflow) {
+	for _, step := range workflow.Steps {
+		if step.IncludeWorkflow != nil {
+			//recurse into included workflow
+			updateWorkflow(step.IncludeWorkflow.Workflow)
+		}
+		if step.CreateInstances != nil {
+			for _, instance := range *step.CreateInstances {
+				instance.Instance.Labels = updateResourceLabels(instance.Instance.Labels, "")
+				if *noExternalIP {
+					configureInstanceNetworkInterfaceForNoExternalIP(instance)
+				}
+			}
+		}
+		if step.CreateDisks != nil {
+			for _, disk := range *step.CreateDisks {
+				disk.Disk.Labels = updateResourceLabels(disk.Disk.Labels, "")
+			}
+		}
+		if step.CreateImages != nil {
+			for _, image := range *step.CreateImages {
+				image.Image.Labels = updateResourceLabels(image.Image.Labels, getImageTypeLabelKey(image))
+			}
+		}
+	}
+}
+
+func getImageTypeLabelKey(image *daisy.Image) string {
+	imageTypeLabel := "gce-image-import"
+	if strings.Contains(image.Image.Name, "untranslated") {
+		imageTypeLabel = "gce-image-import-tmp"
+	}
+	return imageTypeLabel
+}
+
+func configureInstanceNetworkInterfaceForNoExternalIP(instance *daisy.Instance) {
+	if instance.Instance.NetworkInterfaces == nil {
+		return
+	}
+	for _, networkInterface := range instance.Instance.NetworkInterfaces {
+		networkInterface.AccessConfigs = []*compute.AccessConfig{}
+	}
+}
+
+func updateResourceLabels(labels map[string]string, imageTypeLabel string) map[string]string {
+	labels = extendWithImageImportLabels(labels, imageTypeLabel)
+	labels = extendWithUserLabels(labels)
+	return labels
+}
+
+//Extend labels with image import related labels
+func extendWithImageImportLabels(labels map[string]string, imageTypeLabel string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	if imageTypeLabel == "" {
+		imageTypeLabel = "gce-image-import-tmp"
+	}
+	labels[imageTypeLabel] = "true"
+	labels["gce-image-import-build-id"] = buildID
+
+	return labels
+}
+
+func extendWithUserLabels(labels map[string]string) map[string]string {
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	if userLabels == nil || len(*userLabels) == 0 {
+		return labels
+	}
+
+	for key, value := range *userLabels {
+		labels[key] = value
+	}
+	return labels
+}
+
+func buildDaisyVars(translateWorkflowPath string) map[string]string {
+	varMap := map[string]string{}
+
+	varMap["image_name"] = *imageName
+	if translateWorkflowPath != "" {
+		varMap["translate_workflow"] = translateWorkflowPath
+		varMap["install_gce_packages"] = strconv.FormatBool(!*noGuestEnvironment)
+	}
+	//TODO: copy sourceFile to gcsPath. NOTE: This maybe has to be done externally due to missing
+	//permissions of argo service account
+	if *sourceFile != "" {
+		varMap["source_disk_file"] = *sourceFile
+	}
+	if *sourceImage != "" {
+		varMap["source_image"] = fmt.Sprintf("global/images/%v", *sourceImage)
+	}
+	varMap["family"] = *family
+	varMap["description"] = *description
+	if *network != "" {
+		varMap["import_network"] = fmt.Sprintf("global/networks/%v", *network)
+	}
+	if *subnet != "" {
+		varMap["import_subnet"] = fmt.Sprintf("regions/%v/subnetworks/%v", *region, *subnet)
+	}
+	return varMap
+}
+
+func main() {
+	fatalIfError(validateAndParseFlags)
+	populateMissingParameters()
+
+	ctx := context.Background()
+
+	importWorkflowPath, translateWorkflowPath := getWorkflowPaths()
+
+	varMap := buildDaisyVars(translateWorkflowPath)
+	workflow, err := daisycommon.ParseWorkflow(ctx, importWorkflowPath, varMap, *project, *zone,
+		*scratchBucketGcsPath, *oauth, *timeout, *ce, *gcsLogsDisabled, *cloudLogsDisabled,
+		*stdoutLogsDisabled)
+
+	if err != nil {
+		log.Fatalf("Error parsing workflow %q: %v", importWorkflowPath, err)
+	}
+
+	if err := workflow.RunWithModifier(ctx, updateWorkflow); err != nil {
+		log.Fatalf("%s: %v", workflow.Name, err)
+	}
+}

--- a/cli_tools/gce_vm_image_import/main_test.go
+++ b/cli_tools/gce_vm_image_import/main_test.go
@@ -1,0 +1,711 @@
+//  Copyright 2018 Google Inc. All Rights Reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"github.com/GoogleCloudPlatform/compute-image-tools/daisy"
+	"google.golang.org/api/compute/v1"
+	"os"
+	"testing"
+)
+
+func TestGetRegion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+		err   error
+	}{
+		{"us-central1-c", "us-central1", nil},
+		{"europe-north1-a", "europe-north1", nil},
+		{"europe", "", fmt.Errorf("%v is not a valid zone", "europe")},
+		{"", "", fmt.Errorf("zone is empty. Can't determine region")},
+	}
+
+	oldZone := zone
+	for _, test := range tests {
+		zone = &test.input
+		got, err := getRegion()
+		if test.want != got {
+			t.Errorf("%v != %v", test.want, got)
+		} else if err != test.err && test.err.Error() != err.Error() {
+			t.Errorf("%v != %v", test.err, err)
+		}
+	}
+	zone = oldZone
+}
+
+func TestPopulateRegion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+		err   error
+	}{
+		{"us-central1-c", "us-central1", nil},
+		{"europe", "", fmt.Errorf("%v is not a valid zone", "europe")},
+		{"", "", fmt.Errorf("zone is empty. Can't determine region")},
+	}
+
+	oldZone := zone
+	for _, test := range tests {
+		zone = &test.input
+		region = nil
+		err := populateRegion()
+		if err != test.err && test.err.Error() != err.Error() {
+			t.Errorf("%v != %v", test.err, err)
+		} else if region != nil && test.want != *region {
+			t.Errorf("%v != %v", test.want, *region)
+		}
+	}
+	zone = oldZone
+}
+
+func TestGetWorkflowPathsFromImage(t *testing.T) {
+	defer setStringP(&sourceImage, "image-1")()
+	defer setStringP(&osID, "ubuntu-1404")()
+	workflow, translate := getWorkflowPaths()
+	if workflow != importFromImageWorkflow && translate != "ubuntu/translate_ubuntu_1404.wf.json" {
+		t.Errorf("%v != %v and/or translate not empty", workflow, importFromImageWorkflow)
+	}
+}
+
+func TestGetWorkflowPathsDataDisk(t *testing.T) {
+	defer setBoolP(&dataDisk, true)()
+	workflow, translate := getWorkflowPaths()
+	if workflow != importWorkflow && translate != "" {
+		t.Errorf("%v != %v and/or translate not empty", workflow, importWorkflow)
+	}
+}
+
+func TestGetWorkflowPathsFromFile(t *testing.T) {
+	defer setBoolP(&dataDisk, false)()
+	defer setStringP(&sourceImage, "image-1")()
+	defer setStringP(&osID, "ubuntu-1404")()
+	defer setStringP(&sourceImage, "")()
+
+	workflow, translate := getWorkflowPaths()
+
+	if workflow != importAndTranslateWorkflow || translate != "ubuntu/translate_ubuntu_1404.wf.json" {
+		t.Errorf("%v != %v and/or translate not %v", workflow, "ubuntu/translate_ubuntu_1404.wf.json", importAndTranslateWorkflow)
+	}
+}
+
+func TestFlagsImageNameNotProvided(t *testing.T) {
+	err := validateAndParseFlags()
+	expected := fmt.Errorf("The flag -image_name must be provided")
+	if err != expected && err.Error() != expected.Error() {
+		t.Errorf("%v != %v", err, expected)
+	}
+}
+
+func TestFlagsClientIdNotProvided(t *testing.T) {
+	defer backupOsArgs()()
+	cliArgs := getAllCliArgs()
+	defer clearStringFlag(cliArgs, clientIDFlagKey, &clientID)()
+	buildOsArgsAndAssertErrorOnValidate(cliArgs, "Expected error for missing client_id flag", t)
+}
+
+func TestFlagsDataDiskOrOSFlagsNotProvided(t *testing.T) {
+	defer backupOsArgs()()
+	cliArgs := getAllCliArgs()
+	defer clearStringFlag(cliArgs, "os", &osID)()
+	defer clearBoolFlag(cliArgs, "data_disk", &dataDisk)()
+	buildOsArgsAndAssertErrorOnValidate(cliArgs, "Expected error for missing os or data_disk flag", t)
+}
+
+func TestFlagsDataDiskAndOSFlagsBothProvided(t *testing.T) {
+	defer backupOsArgs()()
+	cliArgs := getAllCliArgs()
+	buildOsArgsAndAssertErrorOnValidate(cliArgs, "Expected error for both os and data_disk set at the same time", t)
+}
+
+func TestFlagsSourceFileOrSourceImageNotProvided(t *testing.T) {
+	defer backupOsArgs()()
+	cliArgs := getAllCliArgs()
+	defer clearStringFlag(cliArgs, "source_file", &sourceFile)()
+	defer clearStringFlag(cliArgs, "source_image", &sourceImage)()
+	defer clearBoolFlag(cliArgs, "data_disk", &dataDisk)()
+	buildOsArgsAndAssertErrorOnValidate(cliArgs, "Expected error for missing source_file or source_image flag", t)
+}
+
+func TestFlagsSourceFileAndSourceImageBothProvided(t *testing.T) {
+	defer backupOsArgs()()
+	cliArgs := getAllCliArgs()
+	defer clearBoolFlag(cliArgs, "data_disk", &dataDisk)()
+	buildOsArgsAndAssertErrorOnValidate(cliArgs, "Expected error for both source_file and source_image flags set", t)
+}
+
+func buildOsArgsAndAssertErrorOnValidate(cliArgs map[string]interface{}, errorMsg string, t *testing.T) {
+	buildOsArgs(cliArgs)
+	if err := validateAndParseFlags(); err == nil {
+		t.Error(errorMsg)
+	}
+}
+
+func TestFlagsSourceFile(t *testing.T) {
+	defer backupOsArgs()()
+
+	cliArgs := getAllCliArgs()
+	defer clearStringFlag(cliArgs, "source_image", &sourceImage)()
+	defer clearBoolFlag(cliArgs, "data_disk", &dataDisk)()
+	buildOsArgs(cliArgs)
+
+	if err := validateAndParseFlags(); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestFlagsInvalidSourceFile(t *testing.T) {
+	defer backupOsArgs()()
+
+	cliArgs := getAllCliArgs()
+	cliArgs["source_file"] = "invalidSourceFile"
+	defer clearStringFlag(cliArgs, "source_image", &sourceImage)()
+	defer clearBoolFlag(cliArgs, "data_disk", &dataDisk)()
+	buildOsArgs(cliArgs)
+
+	if err := validateAndParseFlags(); err == nil {
+		t.Errorf("Expected error")
+	}
+}
+
+func TestFlagsSourceImage(t *testing.T) {
+	defer backupOsArgs()()
+
+	cliArgs := getAllCliArgs()
+	defer clearStringFlag(cliArgs, "source_file", &sourceFile)()
+	defer clearBoolFlag(cliArgs, "data_disk", &dataDisk)()
+	buildOsArgs(cliArgs)
+
+	if err := validateAndParseFlags(); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestFlagsDataDisk(t *testing.T) {
+	defer backupOsArgs()()
+
+	cliArgs := getAllCliArgs()
+	defer clearStringFlag(cliArgs, "source_image", &sourceImage)()
+	defer clearStringFlag(cliArgs, "os", &osID)()
+	buildOsArgs(cliArgs)
+
+	if err := validateAndParseFlags(); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestFlagsInvalidOS(t *testing.T) {
+	defer backupOsArgs()()
+
+	cliArgs := getAllCliArgs()
+	defer clearBoolFlag(cliArgs, "data_disk", &dataDisk)()
+	defer clearStringFlag(cliArgs, "source_image", &sourceImage)()
+	cliArgs["os"] = "invalidOs"
+	buildOsArgs(cliArgs)
+
+	if err := validateAndParseFlags(); err == nil {
+		t.Errorf("Expected error")
+	}
+}
+
+func TestUpdateWorkflowInstancesLabelled(t *testing.T) {
+	defer setBoolP(&noExternalIP, false)()
+	buildID = "abc"
+
+	existingLabels := map[string]string{"labelKey": "labelValue"}
+	w := daisy.New()
+	w.Steps = map[string]*daisy.Step{
+		"ci": {
+			CreateInstances: &daisy.CreateInstances{
+				{
+					Instance: compute.Instance{
+						Disks:  []*compute.AttachedDisk{{Source: "key1"}},
+						Labels: map[string]string{"labelKey": "labelValue"},
+					},
+				},
+				{
+					Instance: compute.Instance{
+						Disks: []*compute.AttachedDisk{{Source: "key2"}},
+					},
+				},
+			},
+		},
+	}
+
+	updateWorkflow(w)
+	validateLabels(&(*w.Steps["ci"].CreateInstances)[0].Instance.Labels, "gce-image-import-tmp", t, &existingLabels)
+	validateLabels(&(*w.Steps["ci"].CreateInstances)[1].Instance.Labels, "gce-image-import-tmp", t)
+}
+
+func TestUpdateWorkflowDisksLabelled(t *testing.T) {
+	defer setBoolP(&noExternalIP, false)()
+	buildID = "abc"
+
+	extraLabels := map[string]string{"labelKey": "labelValue"}
+	w := createWorkflowWithCreateDisksStep()
+
+	updateWorkflow(w)
+	validateLabels(&(*w.Steps["cd"].CreateDisks)[0].Disk.Labels, "gce-image-import-tmp", t, &extraLabels)
+	validateLabels(&(*w.Steps["cd"].CreateDisks)[1].Disk.Labels, "gce-image-import-tmp", t)
+}
+
+func createWorkflowWithCreateDisksStep() *daisy.Workflow {
+	w := daisy.New()
+	w.Steps = map[string]*daisy.Step{
+		"cd": {
+			CreateDisks: &daisy.CreateDisks{
+				{
+					Disk: compute.Disk{
+						Labels: map[string]string{"labelKey": "labelValue"},
+					},
+				},
+				{
+					Disk: compute.Disk{},
+				},
+			},
+		},
+	}
+	return w
+}
+
+func TestUpdateWorkflowIncludedWorkflow(t *testing.T) {
+	defer setBoolP(&noExternalIP, false)()
+	buildID = "abc"
+
+	childWorkflow := createWorkflowWithCreateDisksStep()
+	extraLabels := map[string]string{"labelKey": "labelValue"}
+
+	w := daisy.New()
+	w.Steps = map[string]*daisy.Step{
+		"cd": {
+			IncludeWorkflow: &daisy.IncludeWorkflow{
+				Workflow: childWorkflow,
+			},
+		},
+	}
+
+	updateWorkflow(w)
+	validateLabels(&(*childWorkflow.Steps["cd"].CreateDisks)[0].Disk.Labels, "gce-image-import-tmp", t, &extraLabels)
+	validateLabels(&(*childWorkflow.Steps["cd"].CreateDisks)[1].Disk.Labels, "gce-image-import-tmp", t)
+}
+
+func TestUpdateWorkflowImagesLabelled(t *testing.T) {
+	defer setBoolP(&noExternalIP, false)()
+	buildID = "abc"
+
+	w := daisy.New()
+	extraLabels := map[string]string{"labelKey": "labelValue"}
+	w.Steps = map[string]*daisy.Step{
+		"cimg": {
+			CreateImages: &daisy.CreateImages{
+				{
+					Image: compute.Image{
+						Name:   "final-image-1",
+						Labels: map[string]string{"labelKey": "labelValue"},
+					},
+				},
+				{
+					Image: compute.Image{
+						Name: "final-image-2",
+					},
+				},
+				{
+					Image: compute.Image{
+						Name:   "untranslated-image-1",
+						Labels: map[string]string{"labelKey": "labelValue"},
+					},
+				},
+				{
+					Image: compute.Image{
+						Name: "untranslated-image-2",
+					},
+				},
+			},
+		},
+	}
+
+	updateWorkflow(w)
+
+	validateLabels(&(*w.Steps["cimg"].CreateImages)[0].Image.Labels, "gce-image-import", t, &extraLabels)
+	validateLabels(&(*w.Steps["cimg"].CreateImages)[1].Image.Labels, "gce-image-import", t)
+
+	validateLabels(&(*w.Steps["cimg"].CreateImages)[2].Image.Labels, "gce-image-import-tmp", t, &extraLabels)
+	validateLabels(&(*w.Steps["cimg"].CreateImages)[3].Image.Labels, "gce-image-import-tmp", t)
+}
+
+func TestUpdateWorkflowInstancesConfiguredForNoExternalIP(t *testing.T) {
+	defer setBoolP(&noExternalIP, true)()
+
+	w := createWorkflowWithCreateInstanceNetworkAccessConfig()
+	updateWorkflow(w)
+
+	if len((*w.Steps["ci"].CreateInstances)[0].Instance.NetworkInterfaces[0].AccessConfigs) != 0 {
+		t.Errorf("Instance AccessConfigs not empty")
+	}
+}
+
+func TestUpdateWorkflowInstancesNotModifiedIfExternalIPAllowed(t *testing.T) {
+	defer setBoolP(&noExternalIP, false)()
+
+	w := createWorkflowWithCreateInstanceNetworkAccessConfig()
+	updateWorkflow(w)
+
+	if len((*w.Steps["ci"].CreateInstances)[0].Instance.NetworkInterfaces[0].AccessConfigs) != 1 {
+		t.Errorf("Instance AccessConfigs doesn't have exactly one instance")
+	}
+}
+
+func TestUpdateWorkflowInstancesNotModifiedIfNoNetworkInterfaceElement(t *testing.T) {
+	defer setBoolP(&noExternalIP, true)()
+	w := createWorkflowWithCreateInstanceNetworkAccessConfig()
+	(*w.Steps["ci"].CreateInstances)[0].Instance.NetworkInterfaces = nil
+	updateWorkflow(w)
+
+	if (*w.Steps["ci"].CreateInstances)[0].Instance.NetworkInterfaces != nil {
+		t.Errorf("Instance NetworkInterfaces should stay nil if nil before update")
+	}
+}
+
+func TestBuildDaisyVarsFromDisk(t *testing.T) {
+	defer setStringP(&imageName, "image-a")()
+	defer setBoolP(&noGuestEnvironment, true)()
+	defer setStringP(&sourceFile, "source-file-path")()
+	defer setStringP(&sourceImage, "")()
+	defer setStringP(&family, "a-family")()
+	defer setStringP(&description, "a-description")()
+	defer setStringP(&network, "a-network")()
+	defer setStringP(&subnet, "a-subnet")()
+	defer setStringP(&region, "a-region")()
+
+	got := buildDaisyVars("translate/workflow/path")
+
+	assertEqual(got["image_name"], "image-a", t)
+	assertEqual(got["translate_workflow"], "translate/workflow/path", t)
+	assertEqual(got["install_gce_packages"], "false", t)
+	assertEqual(got["source_disk_file"], "source-file-path", t)
+	assertEqual(got["family"], "a-family", t)
+	assertEqual(got["description"], "a-description", t)
+	assertEqual(got["import_network"], "global/networks/a-network", t)
+	assertEqual(got["import_subnet"], "regions/a-region/subnetworks/a-subnet", t)
+	assertEqual(len(got), 8, t)
+}
+
+func TestBuildDaisyVarsFromImage(t *testing.T) {
+	defer setStringP(&imageName, "image-a")()
+	defer setBoolP(&noGuestEnvironment, true)()
+	defer setStringP(&sourceFile, "")()
+	defer setStringP(&sourceImage, "source-image")()
+	defer setStringP(&family, "a-family")()
+	defer setStringP(&description, "a-description")()
+	defer setStringP(&network, "a-network")()
+	defer setStringP(&subnet, "a-subnet")()
+	defer setStringP(&region, "a-region")()
+
+	got := buildDaisyVars("translate/workflow/path")
+
+	assertEqual(got["image_name"], "image-a", t)
+	assertEqual(got["translate_workflow"], "translate/workflow/path", t)
+	assertEqual(got["install_gce_packages"], "false", t)
+	assertEqual(got["source_image"], "global/images/source-image", t)
+	assertEqual(got["family"], "a-family", t)
+	assertEqual(got["description"], "a-description", t)
+	assertEqual(got["import_network"], "global/networks/a-network", t)
+	assertEqual(got["import_subnet"], "regions/a-region/subnetworks/a-subnet", t)
+	assertEqual(len(got), 8, t)
+}
+
+var onGCE *bool
+var gceZone *string
+var gceMetadataError error
+
+func TestPopulateZoneIfMissingOnGCESuccess(t *testing.T) {
+	defer setBoolP(&onGCE, true)()
+	defer setStringP(&gceZone, "europe-north1-c")()
+	defer setStringP(&zone, "")()
+	err := populateZoneIfMissing(dummyMetadataGCE{})
+
+	assertNil(err, t)
+	assertEqual(*zone, "europe-north1-c", t)
+}
+
+func TestPopulateZoneIfMissingNotOnGCEZoneDoesntChange(t *testing.T) {
+	defer setBoolP(&onGCE, false)()
+	defer setStringP(&zone, "us-west-1c")()
+	defer setStringP(&gceZone, "europe-north1-c")()
+
+	err := populateZoneIfMissing(dummyMetadataGCE{})
+
+	assertNil(err, t)
+	assertEqual(*zone, "us-west-1c", t)
+}
+
+func TestPopulateZoneIfMissingOnGCEError(t *testing.T) {
+	defer setBoolP(&onGCE, true)()
+	defer setStringP(&gceZone, "europe-north1-c")()
+	defer setStringP(&zone, "")()
+	gceMetadataError = fmt.Errorf("zone error")
+
+	assertError(populateZoneIfMissing(dummyMetadataGCE{}), t)
+
+	gceMetadataError = nil
+}
+
+func TestPopulateZoneIfMissingOnGCEEnmptyZoneReturned(t *testing.T) {
+	defer setBoolP(&onGCE, true)()
+	defer setStringP(&gceZone, "")()
+	defer setStringP(&zone, "")()
+	assertError(populateZoneIfMissing(dummyMetadataGCE{}), t)
+}
+
+func TestParseUserLabelsReturnsEmptyMap(t *testing.T) {
+	labels := ""
+	labelsMap, err := parseUserLabels(&labels)
+	assertNil(err, t)
+	assertNotNil(labelsMap, t)
+	if len(*labelsMap) > 0 {
+		t.Errorf("Labels map %v should be empty, but it's size is %v.", labelsMap, len(*labelsMap))
+	}
+}
+
+func TestParseUserLabels(t *testing.T) {
+	doTestParseUserLabels("userkey1=uservalue1,userkey2=uservalue2", t)
+}
+
+func TestParseUserLabelsWithWhiteChars(t *testing.T) {
+	doTestParseUserLabels("	 userkey1 = uservalue1	,	 userkey2	 =	 uservalue2	 ", t)
+}
+
+func doTestParseUserLabels(labels string, t *testing.T) {
+	labelsMap, err := parseUserLabels(&labels)
+	assertNil(err, t)
+	assertNotNil(labelsMap, t)
+	if len(*labelsMap) != 2 {
+		t.Errorf("Labels map %v should be have size 2, but it's %v.", labelsMap, len(*labelsMap))
+	}
+	assertEqual("uservalue1", (*labelsMap)["userkey1"], t)
+	assertEqual("uservalue2", (*labelsMap)["userkey2"], t)
+}
+
+func TestParseUserLabelsNoEqualsSignSingleLabel(t *testing.T) {
+	doTestParseUserLabelsNoEqualsSign("userkey1", t)
+}
+
+func TestParseUserLabelsNoEqualsSignLast(t *testing.T) {
+	doTestParseUserLabelsNoEqualsSign("userkey2=uservalue2,userkey1", t)
+}
+
+func TestParseUserLabelsNoEqualsSignFirst(t *testing.T) {
+	doTestParseUserLabelsNoEqualsSign("userkey1,userkey2=uservalue2", t)
+}
+
+func TestParseUserLabelsNoEqualsSignMiddle(t *testing.T) {
+	doTestParseUserLabelsNoEqualsSign("userkey3=uservalue3,userkey1,userkey2=uservalue2", t)
+}
+
+func TestParseUserLabelsNoEqualsSignMultiple(t *testing.T) {
+	doTestParseUserLabelsNoEqualsSign("userkey1,userkey2", t)
+}
+
+func TestParseUserLabelsWhiteSpacesOnlyInKey(t *testing.T) {
+	doTestParseUserLabelsError(" 	=uservalue1", "Labels map %v should be nil for %v", t)
+}
+
+func TestParseUserLabelsWhiteSpacesOnlyInValue(t *testing.T) {
+	doTestParseUserLabelsError("userkey= 	", "Labels map %v should be nil for %v", t)
+}
+
+func TestParseUserLabelsWhiteSpacesOnlyInKeyAndValue(t *testing.T) {
+	doTestParseUserLabelsError(" 	= 	", "Labels map %v should be nil for %v", t)
+}
+
+func doTestParseUserLabelsNoEqualsSign(labels string, t *testing.T) {
+	doTestParseUserLabelsError(labels, "Labels map %v should be nil for v%", t)
+}
+
+func doTestParseUserLabelsError(labels string, errorMsg string, t *testing.T) {
+	labelsMap, err := parseUserLabels(&labels)
+	if labelsMap != nil {
+		t.Errorf(errorMsg, labelsMap, labels)
+	}
+	assertNotNil(err, t)
+}
+
+type dummyMetadataGCE struct{}
+
+func (m dummyMetadataGCE) OnGCE() bool {
+	return *onGCE
+}
+
+func (m dummyMetadataGCE) Zone() (string, error) {
+	return *gceZone, gceMetadataError
+}
+
+func assertEqual(i1 interface{}, i2 interface{}, t *testing.T) {
+	if i1 != i2 {
+		t.Errorf("%v != %v", i1, i2)
+	}
+}
+
+func assertNotNil(i1 interface{}, t *testing.T) {
+	if i1 == nil {
+		t.Errorf("%v is nil", i1)
+	}
+}
+
+func assertNil(i1 interface{}, t *testing.T) {
+	if i1 != nil {
+		t.Errorf("%v not nil", i1)
+	}
+}
+
+func assertError(err error, t *testing.T) {
+	if err == nil {
+		t.Errorf("%v error is empty", err)
+	}
+}
+
+func createWorkflowWithCreateInstanceNetworkAccessConfig() *daisy.Workflow {
+	w := daisy.New()
+	w.Steps = map[string]*daisy.Step{
+		"ci": {
+			CreateInstances: &daisy.CreateInstances{
+				{
+					Instance: compute.Instance{
+						Disks: []*compute.AttachedDisk{{Source: "key1"}},
+						NetworkInterfaces: []*compute.NetworkInterface{
+							{
+								Network: "n",
+								AccessConfigs: []*compute.AccessConfig{
+									{Type: "ONE_TO_ONE_NAT"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return w
+}
+
+func validateLabels(labels *map[string]string, typeLabel string, t *testing.T, extraLabelsArr ...*map[string]string) {
+	var extraLabels *map[string]string
+	if len(extraLabelsArr) > 0 {
+		extraLabels = extraLabelsArr[0]
+	}
+	extraLabelCount := 0
+	if extraLabels != nil {
+		extraLabelCount = len(*extraLabels)
+	}
+	expectedLabelCount := extraLabelCount + 4
+	if len(*labels) != expectedLabelCount {
+		t.Errorf("Labels %v should have only %v elements", labels, expectedLabelCount)
+	}
+	assertEqual(buildID, (*labels)["gce-image-import-build-id"], t)
+	assertEqual("true", (*labels)[typeLabel], t)
+	assertEqual("uservalue1", (*labels)["userkey1"], t)
+	assertEqual("uservalue2", (*labels)["userkey2"], t)
+
+	if extraLabels != nil {
+		for extraKey, extraValue := range *extraLabels {
+			if value, ok := (*labels)[extraKey]; !ok || value != extraValue {
+				t.Errorf("Key %v from labels missing or value %v not matching", extraKey, value)
+			}
+		}
+	}
+}
+
+func backupOsArgs() func() {
+	oldArgs := os.Args
+	return func() { os.Args = oldArgs }
+}
+
+func buildOsArgs(cliArgs map[string]interface{}) {
+	os.Args = make([]string, len(cliArgs)+1)
+	i := 0
+	os.Args[i] = "cmd"
+	i++
+	for key, value := range cliArgs {
+		if value != nil {
+			os.Args[i] = formatCliArg(key, value)
+			i++
+		}
+	}
+}
+
+func formatCliArg(argKey, argValue interface{}) string {
+	if argValue == true {
+		return fmt.Sprintf("-%v", argKey)
+	}
+	if argValue != false {
+		return fmt.Sprintf("-%v=%v", argKey, argValue)
+	}
+	return ""
+}
+
+func getAllCliArgs() map[string]interface{} {
+	return map[string]interface{}{
+		imageNameFlagKey:            "img",
+		clientIDFlagKey:             "aClient",
+		"data_disk":                 true,
+		"os":                        "ubuntu-1404",
+		"source_file":               "gs://source_bucket/source_file",
+		"source_image":              "anImage",
+		"no_guest_environment":      true,
+		"family":                    "aFamily",
+		"description":               "aDescription",
+		"network":                   "aNetwork",
+		"subnet":                    "aSubnet",
+		"timeout":                   "2h",
+		"zone":                      "us-central1-c",
+		"project":                   "aProject",
+		"scratch_bucket_gcs_path":   "gs://bucket/folder",
+		"oauth":                     "oAuthFilePath",
+		"compute_endpoint_override": "us-east1-c",
+		"disable_gcs_logging":       true,
+		"disable_cloud_logging":     true,
+		"disable_stdout_logging":    true,
+		"kms_key":                   "aKmsKey",
+		"kms_keyring":               "aKmsKeyRing",
+		"kms_location":              "aKmsLocation",
+		"kms_project":               "aKmsProject",
+		"labels":                    "userkey1=uservalue1,userkey2=uservalue2",
+	}
+}
+
+func setStringP(p **string, value string) func() {
+	oldValue := *p
+	*p = &value
+	return func() {
+		*p = oldValue
+	}
+}
+
+func setBoolP(p **bool, value bool) func() {
+	oldValue := *p
+	*p = &value
+	return func() { *p = oldValue }
+}
+
+func clearStringFlag(cliArgs map[string]interface{}, flagKey string, flag **string) func() {
+	delete(cliArgs, flagKey)
+	return setStringP(flag, "")
+}
+
+func clearBoolFlag(cliArgs map[string]interface{}, flagKey string, flag **bool) func() {
+	delete(cliArgs, flagKey)
+	return setBoolP(flag, false)
+}

--- a/daisy/workflow.go
+++ b/daisy/workflow.go
@@ -201,11 +201,23 @@ func (w *Workflow) Validate(ctx context.Context) error {
 	return nil
 }
 
+// WorkflowModifier is a function type for functions that can modify a Workflow object.
+type WorkflowModifier func(*Workflow)
+
 // Run runs a workflow.
 func (w *Workflow) Run(ctx context.Context) error {
+	return w.RunWithModifier(ctx, nil)
+}
+
+// RunWithModifier runs a workflow with the ability to modify it once validated but before it's actually run.
+func (w *Workflow) RunWithModifier(ctx context.Context, workflowModifier WorkflowModifier) error {
 	w.externalLogging = true
 	if err := w.Validate(ctx); err != nil {
 		return err
+	}
+
+	if workflowModifier != nil {
+		workflowModifier(w)
 	}
 	defer w.cleanup()
 	w.LogWorkflowInfo("Workflow Project: %s", w.Project)

--- a/daisy_latest_cloudbuild.yaml
+++ b/daisy_latest_cloudbuild.yaml
@@ -29,8 +29,14 @@ steps:
 - name: 'gcr.io/cloud-builders/go'
   args: ['build', '-o=linux/import_precheck', 'github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/import_precheck']
   env: ['CGO_ENABLED=0']
+- name: 'gcr.io/cloud-builders/go'
+  args: ['build', '-o=linux/gce_vm_image_import', 'github.com/GoogleCloudPlatform/compute-image-tools/cli_tools/gce_vm_image_import']
+  env: ['CGO_ENABLED=0']
+
+# Copy Linux binaries to GS
 - name: 'gcr.io/cloud-builders/gsutil'
   args: ['cp', './linux/*', 'gs://compute-image-tools/latest/linux/']
+
 # Build Linux containers.
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/daisy:latest', '--tag=gcr.io/$PROJECT_ID/daisy:$COMMIT_SHA', '--file=Dockerfile.daisy', '.']
@@ -38,6 +44,8 @@ steps:
   args: ['build', '--tag=gcr.io/$PROJECT_ID/gce_image_publish:latest', '--tag=gcr.io/$PROJECT_ID/gce_image_publish:$COMMIT_SHA', '--file=Dockerfile.gce_image_publish', '.']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=gcr.io/$PROJECT_ID/gce_export:latest', '--tag=gcr.io/$PROJECT_ID/gce_export:$COMMIT_SHA', '--file=Dockerfile.gce_export', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/gce_vm_image_import:latest', '--file=Dockerfile.gce_vm_image_import', '.']
 
 # Build Windows binaries.
 - name: 'gcr.io/cloud-builders/go'
@@ -76,3 +84,5 @@ images:
   - 'gcr.io/$PROJECT_ID/gce_image_publish:$COMMIT_SHA'
   - 'gcr.io/$PROJECT_ID/gce_export:latest'
   - 'gcr.io/$PROJECT_ID/gce_export:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/gce_vm_image_import:latest'
+  - 'gcr.io/$PROJECT_ID/gce_vm_image_import:$COMMIT_SHA'


### PR DESCRIPTION
* GCE VM Image importer - first version: does the same funcionality as Daisy with the added ability to tag resources created during import as well as change network parameters to support no external IP VPC config (controlled by a parameter).

* Daisy image import from image: added network/subnet param forwarding to translate workflow. Without this, import from image doesn't work when non-default networks are present.

* Daisy image import from image: added labels flag